### PR TITLE
Fix/responsive home

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -145,7 +145,7 @@ export class App extends Component {
                             href="https://loja.queplanta.com/"
                             component="a"
                           >
-                            Loja{" "}
+                            Loja&nbsp;
                             <Chip
                               label="Novidade"
                               color="primary"

--- a/src/Home/index.js
+++ b/src/Home/index.js
@@ -11,6 +11,7 @@ import RecentPosts from "./RecentPosts.js";
 import VisitShop from "./VisitShop.js";
 import { Width } from "../ui";
 import mapExample from "../assets/map-example.jpg";
+import { FullscreenExit } from "@material-ui/icons";
 
 function Home(props) {
   const { classes, environment, viewer } = props;
@@ -77,19 +78,17 @@ const styles = (theme) => ({
     paddingBottom: theme.spacing(2),
   },
   mapLink: {
-    display: "inline-block",
+    display: "flex",
     borderRadius: "4px",
     boxShadow:
       "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
     position: "relative",
     overflow: "hidden",
+    justifyContent: "center",
   },
   mapTitle: {
     position: "absolute",
-    top: "50%",
-    left: "50%",
-    marginLeft: -166,
-    marginTop: -37,
+    alignSelf: "center",
     background: "rgba(0, 0, 0, 0.6)",
     fontWeight: "bold",
     fontSize: 40,
@@ -102,10 +101,10 @@ const styles = (theme) => ({
   },
   map: {
     height: "100%",
-    minHeight: 200,
-    display: "block",
+    display: "flex",
     [theme.breakpoints.down("sm")]: {
-      height: "240px",
+      marginTop: "20px",
+      width: "100%",
     },
   },
   BannerAddPlant: {


### PR DESCRIPTION
Fixed some details on responsively homepage. Like this:

![image](https://user-images.githubusercontent.com/61601716/100138154-56a60a80-2e6c-11eb-8886-e80fa43e4c20.png)

![image](https://user-images.githubusercontent.com/61601716/100138204-6aea0780-2e6c-11eb-990a-5585673eaabf.png)

I also added spacing when menu is hidden (small screens)

![image](https://user-images.githubusercontent.com/61601716/100138435-ca481780-2e6c-11eb-8a43-9b18334bf5dd.png)

Added white space between "Loja" and the label "novidade"

![image](https://user-images.githubusercontent.com/61601716/100138527-eea3f400-2e6c-11eb-8925-29a5785c4389.png)


